### PR TITLE
Add docker-compose with Samba AD, NGINX, LDAP and RADIUS

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+  "image": "ghcr.io/stuartleeks/dev-container-features/add-host:1",
+  "image": "mcr.microsoft.com/devcontainers/universal:2",
+ "features": {}
+  
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# LDAP-NGIX-CLOUD
+
+This compose file deploys an Active Directory domain controller using Samba, an NGINX reverse proxy, an LDAP service and a RADIUS server. The services share a bridged network (`192.168.65.0/24`) so they can be reached by other networks such as `192.168.1.0/24` and `192.168.13.0/27` via your router.
+
+## Services
+
+- **TEAMELITEAD** – Samba Active Directory domain controller for the domain `SAMBA-DOMAIN`.
+- **NGINX** – Reverse proxy exposing HTTP and HTTPS on the container host. Forward these ports on your router to the container's IP within `192.168.65.0/24`.
+- **OpenLDAP** – Provides LDAP directory service that can be used by other devices (e.g. UniFi Dream Machine) for RADIUS authentication.
+- **FreeRADIUS** – Example RADIUS server pointed at the LDAP service. Further configuration is required before production use.
+
+## Network
+
+The `adnet` network is created with a static subnet of `192.168.65.0/24`. Each service is assigned a static IP so that routing and firewall rules can be applied consistently. Ensure your router has routes allowing `192.168.1.0/24` and `192.168.13.0/27` to reach this subnet.
+
+## Volumes
+
+The Active Directory service stores its database on the `ad-data` volume, which is limited to 15GB.
+
+## Usage
+
+1. Adjust passwords and domain names in `docker-compose.yml` as needed.
+2. Start the stack:
+   ```
+   docker compose up -d
+   ```
+3. Configure your router to forward ports 80 and 443 to the IP assigned to the NGINX container (e.g. `192.168.65.20`).
+4. Configure your Dream Machine to use the LDAP or RADIUS services as required.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,71 @@
+version: '3.8'
+
+services:
+  samba_ad:
+    image: danielguerra/alpine-samba-ad:latest
+    container_name: TEAMELITEAD
+    environment:
+      SAMBA_DOMAIN: SAMBA-DOMAIN
+      SAMBA_REALM: SAMBA-DOMAIN.LOCAL
+      SAMBA_ADMIN_PASSWORD: ChangeMe123!
+      HOSTNAME: TEAMELITEAD
+    volumes:
+      - ad-data:/var/lib/samba
+    networks:
+      adnet:
+        ipv4_address: 192.168.65.10
+
+  nginx:
+    image: nginx:alpine
+    depends_on:
+      - samba_ad
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+    ports:
+      - "80:80"
+      - "443:443"
+    networks:
+      adnet:
+        ipv4_address: 192.168.65.20
+
+  openldap:
+    image: osixia/openldap:1.5.0
+    environment:
+      LDAP_ORGANISATION: "Samba Domain"
+      LDAP_DOMAIN: "samba-domain.local"
+      LDAP_ADMIN_PASSWORD: admin
+    volumes:
+      - ldap-data:/var/lib/ldap
+      - ldap-config:/etc/ldap/slapd.d
+    networks:
+      adnet:
+        ipv4_address: 192.168.65.30
+
+  freeradius:
+    image: freeradius/freeradius-server:latest
+    depends_on:
+      - openldap
+    environment:
+      FREERADIUS_LDAP_URI: ldap://openldap
+    networks:
+      adnet:
+        ipv4_address: 192.168.65.40
+    command: ["freeradius", "-X"]
+
+networks:
+  adnet:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 192.168.65.0/24
+          gateway: 192.168.65.1
+
+volumes:
+  ad-data:
+    driver: local
+    driver_opts:
+      type: tmpfs
+      device: tmpfs
+      o: size=15g
+  ldap-data:
+  ldap-config:

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,22 @@
+events {}
+http {
+    upstream samba_backend {
+        server samba_ad:80;
+    }
+
+    server {
+        listen 80;
+        location / {
+            proxy_pass http://samba_backend;
+        }
+    }
+
+    server {
+        listen 443 ssl;
+        ssl_certificate /etc/ssl/certs/ssl-cert-snakeoil.pem;
+        ssl_certificate_key /etc/ssl/private/ssl-cert-snakeoil.key;
+        location / {
+            proxy_pass http://samba_backend;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add docker-compose.yml configuring Samba Active Directory server TEAMELITEAD with OpenLDAP, FreeRADIUS and NGINX reverse proxy on a 192.168.65.0/24 network
- Provide nginx reverse proxy configuration
- Document network, services and usage in README

## Testing
- `python - <<'PY'
import yaml
yaml.safe_load(open('docker-compose.yml'))
print('docker-compose.yml is valid YAML')
PY`
- `docker compose config >/tmp/docker_config.log && tail -n 20 /tmp/docker_config.log` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd7cda0408832ca82cff1368e2eaf6